### PR TITLE
fix: Added PyYAML in requirements!

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 requests_cache
 pyfiglet
+pyyaml


### PR DESCRIPTION
Hi there,

Not everyone has **[PyYAML](https://github.com/yaml/pyyaml)** installed by default; therefore, I have added it into the **`requirements.txt`** file.

Thanks,
@TheBinitGhimire